### PR TITLE
Implement __isset function in Model class

### DIFF
--- a/src/Pinterest/Models/Model.php
+++ b/src/Pinterest/Models/Model.php
@@ -89,6 +89,17 @@ class Model implements \JsonSerializable {
     }
 
     /**
+     * Check if the model's attribute is set
+     *
+     * @param $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return array_key_exists($key, $this->attributes);
+    }
+
+    /**
      * Fill the attributes
      *
      * @access private


### PR DESCRIPTION
For using the model classes in Twig templates the __isset function needs to be implemented. Like explained here: http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties