### PR TITLE
Added original_link to available object keys

### DIFF
--- a/src/Pinterest/Models/Pin.php
+++ b/src/Pinterest/Models/Pin.php
@@ -17,6 +17,6 @@ class Pin extends Model {
      * 
      * @var array
      */
-    protected $fillable = ["id", "link", "url", "creator", "board", "created_at", "note", "color", "counts", "media", "attribution", "image", "metadata"];
+    protected $fillable = ["id", "link", "url", "creator", "board", "created_at", "note", "color", "counts", "media", "attribution", "image", "metadata", "original_link"];
 
 }


### PR DESCRIPTION
I suspect this was either an omission, or Pinterest have added this option (seen via GET/v1/boards/<board_spec:board>/pins/ on the API explorer)