### PR TITLE
Fix safe_mode detection

### DIFF
--- a/src/Pinterest/Utils/CurlBuilder.php
+++ b/src/Pinterest/Utils/CurlBuilder.php
@@ -185,7 +185,7 @@ class CurlBuilder {
         $mr = 5;
         $body = null;
 
-        if (ini_get("open_basedir") == "" && ini_get("safe_mode" == "Off")) {
+        if (ini_get("open_basedir") === "" && ini_get("safe_mode") === false) {
             $this->setOptions(array(
                 CURLOPT_FOLLOWLOCATION => $mr > 0,
                 CURLOPT_MAXREDIRS => $mr


### PR DESCRIPTION
I believe there is a little bug with `ini_get("safe_mode")` that prevents the default code from being executed for most people. 
@pavolsenko this should solve all of your problems. 