### PR TITLE
Change return type of Response::__get()

### DIFF
--- a/src/Pinterest/Transport/Response.php
+++ b/src/Pinterest/Transport/Response.php
@@ -67,7 +67,7 @@ class Response {
      *
      * @access public
      * @param  string   $key
-     * @return array
+     * @return mixed
      */
     public function __get($key)
     {


### PR DESCRIPTION
It can return other things as well, e.g. `$response->access_token` (which is a string)