### PR TITLE
Exception came correction in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## ![](http://i.imgur.com/cacgQlq.png)  Pinterest API - PHP
 
-[![](https://travis-ci.org/dirkgroenen/Pinterest-API-PHP.svg)](https://travis-ci.org/dirkgroenen/Pinterest-API-PHP) 
-[![](https://img.shields.io/scrutinizer/g/dirkgroenen/Pinterest-API-PHP.svg)](https://scrutinizer-ci.com/g/dirkgroenen/Pinterest-API-PHP/?branch=master) 
-[![](https://img.shields.io/scrutinizer/coverage/g/dirkgroenen/Pinterest-API-PHP.svg)](https://scrutinizer-ci.com/g/dirkgroenen/Pinterest-API-PHP/?branch=master) 
-[![Packagist](https://img.shields.io/packagist/v/dirkgroenen/pinterest-api-php.svg)](https://packagist.org/packages/dirkgroenen/pinterest-api-php) 
-[![Support me with some coffee](https://img.shields.io/badge/donate-paypal-orange.svg)](https://www.paypal.me/dirkgroenen)  
+[![](https://travis-ci.org/dirkgroenen/Pinterest-API-PHP.svg)](https://travis-ci.org/dirkgroenen/Pinterest-API-PHP)
+[![](https://img.shields.io/scrutinizer/g/dirkgroenen/Pinterest-API-PHP.svg)](https://scrutinizer-ci.com/g/dirkgroenen/Pinterest-API-PHP/?branch=master)
+[![](https://img.shields.io/scrutinizer/coverage/g/dirkgroenen/Pinterest-API-PHP.svg)](https://scrutinizer-ci.com/g/dirkgroenen/Pinterest-API-PHP/?branch=master)
+[![Packagist](https://img.shields.io/packagist/v/dirkgroenen/pinterest-api-php.svg)](https://packagist.org/packages/dirkgroenen/pinterest-api-php)
+[![Support me with some coffee](https://img.shields.io/badge/donate-paypal-orange.svg)](https://www.paypal.me/dirkgroenen)
 -------------------
 
 A PHP wrapper for the official [Pinterest API](https://dev.pinterest.com).
@@ -26,7 +26,7 @@ The Pinterest API wrapper is available on Composer.
 composer require dirkgroenen/Pinterest-API-PHP
 ```
 
-If you're not using Composer (which you should start using, unless you've got a good reason not to) you can include the `autoload.php` file in your project. 
+If you're not using Composer (which you should start using, unless you've got a good reason not to) you can include the `autoload.php` file in your project.
 
 ## Simple Example
 ```php
@@ -545,4 +545,6 @@ Returns: `True|PinterestException`
 
 # Examples
 
-There are no examples available yet. Let me know if you have an (example) project using the this library.
+Use can take a look at the `./demo` directory for a simple example.
+
+Let me know if you have an (example) project using the this library.


### PR DESCRIPTION
There is missing @throw statement in some methods & many methods mentions wrong exception name in the @throw, like PinterestExceptions whent he exception name is PinterestException. & also mentioned it's with wrong namespace.

I want to correct this to get better IDE support