### PR TITLE
Add note

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ $pinterest->auth->setState($state);
 ```
 
 ## Rate limit
+> Note that you should call an endpoint first, otherwise `getRateLimit()` will return `unknown`.
 
 ### Get limit
 `getRateLimit();`


### PR DESCRIPTION
- Add a note instructing users to first call an endpoint before using the ratelimit methods (#70)