### PR TITLE
drop testing support for <=7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 before_script:
     - composer self-update
     - composer install --prefer-source --no-interaction

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A PHP wrapper for the official [Pinterest API](https://dev.pinterest.com).
 
 # Requirements
-- PHP 5.4 or higher
+- PHP 5.4 or higher (actively tested on PHP >=7.1)
 - cURL
 - Registered Pinterest App
 


### PR DESCRIPTION
Dropping test support for PHP versions lower than 7.1.