### PR TITLE
Fix getRateLimitRemaining() issue

### DIFF
--- a/src/Pinterest/Pinterest.php
+++ b/src/Pinterest/Pinterest.php
@@ -105,7 +105,8 @@ class Pinterest {
     public function getRateLimit()
     {
         $header = $this->request->getHeaders();
-        return (isset($header['X-Ratelimit-Limit']) ? $header['X-Ratelimit-Limit'] : (isset($header['X-RateLimit-Limit']) ? $header['X-RateLimit-Limit'] : 1000));
+        $lcHeader = array_change_key_case($header, CASE_LOWER);
+        return (isset($lcHeader['x-ratelimit-limit']) ? $lcHeader['x-ratelimit-limit'] : 1000);
     }
 
     /**
@@ -117,6 +118,7 @@ class Pinterest {
     public function getRateLimitRemaining()
     {
         $header = $this->request->getHeaders();
-        return (isset($header['X-Ratelimit-Remaining']) ? $header['X-Ratelimit-Remaining'] : (isset($header['X-RateLimit-Remaining']) ? $header['X-RateLimit-Remaining'] : 'unknown'));
+        $lcHeader = array_change_key_case($header, CASE_LOWER);
+        return (isset($lcHeader['x-ratelimit-remaining']) ? $lcHeader['x-ratelimit-remaining'] : 'unknown');
     }
 }

--- a/src/Pinterest/Pinterest.php
+++ b/src/Pinterest/Pinterest.php
@@ -105,8 +105,10 @@ class Pinterest {
     public function getRateLimit()
     {
         $header = $this->request->getHeaders();
-        $lcHeader = array_change_key_case($header, CASE_LOWER);
-        return (isset($lcHeader['x-ratelimit-limit']) ? $lcHeader['x-ratelimit-limit'] : 1000);
+        if (is_array($header)) {
+            $header = array_change_key_case($header, CASE_LOWER);
+        }
+        return (isset($header['x-ratelimit-limit']) ? $header['x-ratelimit-limit'] : 1000);
     }
 
     /**
@@ -118,7 +120,9 @@ class Pinterest {
     public function getRateLimitRemaining()
     {
         $header = $this->request->getHeaders();
-        $lcHeader = array_change_key_case($header, CASE_LOWER);
-        return (isset($lcHeader['x-ratelimit-remaining']) ? $lcHeader['x-ratelimit-remaining'] : 'unknown');
+        if (is_array($header)) {
+            $header = array_change_key_case($header, CASE_LOWER);
+        }
+        return (isset($header['x-ratelimit-remaining']) ? $header['x-ratelimit-remaining'] : 'unknown');
     }
 }

--- a/src/Pinterest/Pinterest.php
+++ b/src/Pinterest/Pinterest.php
@@ -98,25 +98,25 @@ class Pinterest {
 
     /**
      * Get rate limit from the headers
-     *
+     * response header may change from X-Ratelimit-Limit to X-RateLimit-Limit
      * @access public
      * @return integer
      */
     public function getRateLimit()
     {
         $header = $this->request->getHeaders();
-        return (isset($header['X-Ratelimit-Limit']) ? $header['X-Ratelimit-Limit'] : 1000);
+        return (isset($header['X-Ratelimit-Limit']) ? $header['X-Ratelimit-Limit'] : (isset($header['X-RateLimit-Limit']) ? $header['X-RateLimit-Limit'] : 1000));
     }
 
     /**
      * Get rate limit remaining from the headers
-     *
+     * response header may change from X-Ratelimit-Remaining to X-RateLimit-Remaining
      * @access public
      * @return mixed
      */
     public function getRateLimitRemaining()
     {
         $header = $this->request->getHeaders();
-        return (isset($header['X-Ratelimit-Remaining']) ? $header['X-Ratelimit-Remaining'] : 'unknown');
+        return (isset($header['X-Ratelimit-Remaining']) ? $header['X-Ratelimit-Remaining'] : (isset($header['X-RateLimit-Remaining']) ? $header['X-RateLimit-Remaining'] : 'unknown'));
     }
 }


### PR DESCRIPTION
Fixes dirkgroenen/Pinterest-API-PHP#70
Header Array Case Insensitive Lookup as Pinterest API documentation and Actual response header does not match